### PR TITLE
Prepare Release 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.0.8 (2021-12-02)
+
+
+### Bug Fixes
+
+* Rename e to event. ([c2c79d4](https://github.com/ci010/electron-vue-next/commit/c2c79d4fd037db1592891c5a04ee9ab9fd2305ae))
+
 ### 1.0.7 (2021-12-02)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avas-playground",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "description": "My niece loves to press keys on the keyboard to get Windows to make a DING noise. This app will capture all keyboard input, play DING and harmlessly discard all input while it is running.",
   "repository": {


### PR DESCRIPTION
### Bug Fixes

* Rename e to event. ([c2c79d4](https://github.com/ci010/electron-vue-next/commit/c2c79d4fd037db1592891c5a04ee9ab9fd2305ae))