### PR TITLE
Prepare Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2.0.0 (2021-12-02)
+
+
+### ⚠ BREAKING CHANGES
+
+* release new version with updates
+
+### Bug Fixes
+
+* Rename e to event. ([c2c79d4](https://github.com/ci010/electron-vue-next/commit/c2c79d4fd037db1592891c5a04ee9ab9fd2305ae))
+
+
+### Miscellaneous Chores
+
+* release new version with updates ([c52b2eb](https://github.com/ci010/electron-vue-next/commit/c52b2eba1bf6816a4921c6f41e42c7768a2bf9cf))
+
 ### 1.0.8 (2021-12-02)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avas-playground",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "private": true,
   "description": "My niece loves to press keys on the keyboard to get Windows to make a DING noise. This app will capture all keyboard input, play DING and harmlessly discard all input while it is running.",
   "repository": {


### PR DESCRIPTION
### ⚠ BREAKING CHANGES

* release new version with updates

### Bug Fixes

* Rename e to event. ([c2c79d4](https://github.com/ci010/electron-vue-next/commit/c2c79d4fd037db1592891c5a04ee9ab9fd2305ae))


### Miscellaneous Chores

* release new version with updates ([c52b2eb](https://github.com/ci010/electron-vue-next/commit/c52b2eba1bf6816a4921c6f41e42c7768a2bf9cf))